### PR TITLE
Prioritize legacy samp libs for sampctl

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -4,9 +4,7 @@
 	"entry": "test.pwn",
 	"output": "test.amx",
 	"dependencies": [
-		"openmultiplayer/omp-stdlib",
-		"pawn-lang/samp-stdlib@open.mp",
-		"pawn-lang/pawn-stdlib@open.mp",
+		"pawn-lang/samp-stdlib",
 		"IllidanS4/PawnPlus:v1.4.0.1"
 	]
 }

--- a/test.pwn
+++ b/test.pwn
@@ -1,4 +1,4 @@
-#include <open.mp>
+#include <a_samp>
 
 #define PP_SYNTAX_AWAIT
 #include "eSelection.inc"


### PR DESCRIPTION
People using sampctl on samp servers could encounter problems where sampctl was trying to look for dependencies in 2 different places.
